### PR TITLE
fix 0.7 depwarns

### DIFF
--- a/src/genz-malik.jl
+++ b/src/genz-malik.jl
@@ -12,7 +12,7 @@ with k components equal to λ and other components equal to zero.
 function combos(k::Integer, λ::T, ::Val{n}) where {n, T<:Number}
     combos = Combinatorics.combinations(1:n, k)
     p = Vector{SVector{n,T}}(undef, length(combos))
-    v = MVector{n,T}()
+    v = MVector{n,T}(undef)
     for (i,c) in enumerate(combos)
         v .= 0
         v[c] .= λ
@@ -32,7 +32,7 @@ function signcombos(k::Integer, λ::T, ::Val{n}) where {n, T<:Number}
     combos = Combinatorics.combinations(1:n, k)
     twoᵏ = 1 << k
     p = Vector{SVector{n,T}}(undef, length(combos) * twoᵏ)
-    v = MVector{n,T}()
+    v = MVector{n,T}(undef)
     for (i,c) in enumerate(combos)
         j = (i-1)*twoᵏ + 1
         v .= 0
@@ -124,7 +124,7 @@ function (g::GenzMalik{n,T})(f, a::SVector{n}, b::SVector{n}, norm=vecnorm) wher
     f₃ = zero(f₁)
     twelvef₁ = 12f₁
     maxdivdiff = zero(norm(f₁))
-    divdiff = MVector{n,typeof(maxdivdiff)}()
+    divdiff = MVector{n,typeof(maxdivdiff)}(undef)
     for i = 1:n
         p₂ = Δ .* g.p[1][i]
         f₂ᵢ = f(c + p₂) + f(c - p₂)


### PR DESCRIPTION
Added undef to the uninitialized array constructors which fixes all the depwarns from HCubature that occur when running tests. There is still a depwarn coming from Combinatorics.